### PR TITLE
Gains Adjust Window

### DIFF
--- a/app/Menu.js
+++ b/app/Menu.js
@@ -80,8 +80,8 @@ module.exports=function(gui){
        focus: true,
        position: 'center',
        width: 900,
-       height: 400,
-       toolbar: false
+       height: 570,
+       toolbar: true
       });
       Logger.debug('Opening gains adjust window');
     },

--- a/app/Menu.js
+++ b/app/Menu.js
@@ -79,9 +79,9 @@ module.exports=function(gui){
       gui.Window.open('./windows/gainsAdjust.html',{
        focus: true,
        position: 'center',
-       width: 900,
-       height: 570,
-       toolbar: true
+       width: 1100,
+       height: 550,
+       toolbar: false
       });
       Logger.debug('Opening gains adjust window');
     },

--- a/app/models/Commands.js
+++ b/app/models/Commands.js
@@ -69,6 +69,46 @@ var Commands={
     else{
       Logger.error('Command to not sent since invalid flap value detected! Flap Setpoint:'+flap);
     }
+  },
+  sendKPGain: function(type,gain){
+    if(Validator.isValidNumber(gain)){
+      this.sendCommand('set_'+type+'KPGain',gain);
+    }
+    else{
+      Logger.error('Command to not sent since invalid gain value detected! Gain value:'+gain);
+    }
+  },
+  sendKIGain: function(type, gain){
+    if(Validator.isValidNumber(gain)){
+      this.sendCommand('set_'+type+'KIGain',gain);
+    }
+    else{
+      Logger.error('Command to not sent since invalid gain value detected! Gain value:'+gain);
+    }
+  },
+  sendKDGain: function(type, gain){
+    if(Validator.isValidNumber(gain)){
+      this.sendCommand('set_'+type+'KDGain',gain);
+    }
+    else{
+      Logger.error('Command to not sent since invalid gain value detected! Gain value:'+gain);
+    }
+  },
+  sendPathGain: function(gain){
+    if(Validator.isValidNumber(gain)){
+      this.sendCommand('set_pathGain',gain);
+    }
+    else{
+      Logger.error('Command to not sent since invalid path gain value detected! Gain value:'+gain);
+    }
+  },
+  sendOrbitGain: function(gain){
+    if(Validator.isValidNumber(gain)){
+      this.sendCommand('set_orbitGain',gain);
+    }
+    else{
+      Logger.error('Command to not sent since invalid orbit gain value detected! Gain value:'+gain);
+    }
   }
 }
 

--- a/app/models/Commands.js
+++ b/app/models/Commands.js
@@ -109,6 +109,14 @@ var Commands={
     else{
       Logger.error('Command to not sent since invalid orbit gain value detected! Gain value:'+gain);
     }
+  },
+  showGain: function(value){
+    if(Validator.isValidNumber(value)){
+      this.sendCommand('set_showGain',value);
+    }
+    else{
+      Logger.error('Command to not sent since invalid show gain value detected! Value:'+value);
+    }
   }
 }
 

--- a/app/models/Commands.js
+++ b/app/models/Commands.js
@@ -18,66 +18,56 @@ var Commands={
     Network.connections['data_relay'].write(command+':'+picpilot_config.get('command_password')+'\r\n');
   },
   sendCommand: function(command, value){
-    Network.connections['data_relay'].write(command+':'+value+'\r\n');
+    if(this.checkConnection()){
+      Network.connections['data_relay'].write(command+':'+value+'\r\n');
+    }
   },
   sendRoll: function(roll){
-    if(this.checkConnection()){
-      if(Validator.isValidRoll(roll)){
-        this.sendCommand('set_rollAngle',roll);
-      }
-      else{
-        Logger.error('Command to not sent since invalid roll value detected! Roll:'+roll);
-      }
+    if(Validator.isValidRoll(roll)){
+      this.sendCommand('set_rollAngle',roll);
+    }
+    else{
+      Logger.error('Command to not sent since invalid roll value detected! Roll:'+roll);
     }
   },
   sendPitch: function(pitch){
-    if(this.checkConnection()){
-      if(Validator.isValidPitch(pitch)){
-        this.sendCommand('set_pitchAngle',pitch);
-      }
-      else{
-        Logger.error('Command to not sent since invalid pitch value detected! Pitch:'+pitch);
-      }
+    if(Validator.isValidPitch(pitch)){
+      this.sendCommand('set_pitchAngle',pitch);
+    }
+    else{
+      Logger.error('Command to not sent since invalid pitch value detected! Pitch:'+pitch);
     }
   },
   sendHeading: function(heading){
-    if(this.checkConnection()){
-      if(Validator.isValidHeading(heading)){
-        this.sendCommand('set_heading',heading);
-      }
-      else{
-        Logger.error('Command to not sent since invalid heading value detected! Heading:'+heading);
-      }
+    if(Validator.isValidHeading(heading)){
+      this.sendCommand('set_heading',heading);
+    }
+    else{
+      Logger.error('Command to not sent since invalid heading value detected! Heading:'+heading);
     }
   },
   sendAltitude:function(altitude){
-    if(this.checkConnection()){
-      if(Validator.isValidAltitude(altitude)){
-        this.sendCommand('set_altitude',altitude);
-      }
-      else{
-        Logger.error('Command to not sent since invalid altitude value detected! Altitude:'+altitude);
-      }
+    if(Validator.isValidAltitude(altitude)){
+      this.sendCommand('set_altitude',altitude);
+    }
+    else{
+      Logger.error('Command to not sent since invalid altitude value detected! Altitude:'+altitude);
     }
   },
   sendThrottle:function(throttle){
-    if(this.checkConnection()){
-      if(Validator.isValidThrottle(throttle)){
-        this.sendCommand('set_throttle',throttle);
-      }
-      else{
-        Logger.error('Command to not sent since invalid throttle value detected! Throttle:'+throttle);
-      }
+    if(Validator.isValidThrottle(throttle)){
+      this.sendCommand('set_throttle',throttle);
+    }
+    else{
+      Logger.error('Command to not sent since invalid throttle value detected! Throttle:'+throttle);
     }
   },
   sendFlap:function(flap){
-    if(this.checkConnection()){
-      if(Validator.isValidFlap(flap)){
-        this.sendCommand('set_flap',flap);
-      }
-      else{
-        Logger.error('Command to not sent since invalid flap value detected! Flap Setpoint:'+flap);
-      }
+    if(Validator.isValidFlap(flap)){
+      this.sendCommand('set_flap',flap);
+    }
+    else{
+      Logger.error('Command to not sent since invalid flap value detected! Flap Setpoint:'+flap);
     }
   }
 }

--- a/app/views/GainsAdjustView.js
+++ b/app/views/GainsAdjustView.js
@@ -73,7 +73,7 @@ module.exports=function(Marionette){
       this.verification_quoue=[];//verifies that the gain value sent is the one thats being used
       this.data_callback=null;
     },
-    
+
     onRender:function(){
       this.data_callback=this.dataCallback.bind(this);
       TelemetryData.addListener('data_received',this.data_callback);
@@ -84,9 +84,6 @@ module.exports=function(Marionette){
     },
 
     dataCallback: function(data){
-      console.log('Receiviung dataa!!');
-      console.log(this.verification_quoue);
-
       if(this.verification_quoue.length>0 && data.editing_gain===this.verification_quoue[0].type && data.kd_gain===this.verification_quoue[0].kd
           && data.kp_gain===this.verification_quoue[0].kp && data.ki_gain===this.verification_quoue[0].ki){
         this.verification_quoue[0].button.text('Send');

--- a/app/views/GainsAdjustView.js
+++ b/app/views/GainsAdjustView.js
@@ -1,11 +1,23 @@
 var Template=require('../util/Template');
 var TelemetryData=require('../models/TelemetryData');
+var Commands=require('../models/Commands');
+
+var GAINS={
+  YAW: 0x00,
+  PITCH: 0x01,
+  ROLL: 0x02,
+  HEADING: 0x03,
+  ALTITUDE: 0x04,
+  THROTTLE: 0x05,
+  FLAP: 0x06
+};
 
 module.exports=function(Marionette){
 
   return Marionette.ItemView.extend({
     template:Template('GainsAdjustView'), 
     className:'gainsAdjustView', 
+
     ui:{
       yaw_kd:'#yaw-kd',
       yaw_ki:'#yaw-ki',
@@ -28,27 +40,190 @@ module.exports=function(Marionette){
       flap_kd:'#flap-kd',
       flap_ki:'#flap-ki',
       flap_kp:'#flap-kp',
+      orbit_kp:'#orbit-kp',
+      path_kp:'#path-kp',
+
       send_all:'#send-all-gains-button',
-      reset_all:'#reset-default-gains-button'
+      reset_all:'#reset-default-gains-button',
+      yaw_send_button:'#send-yaw-gain-button',
+      pitch_send_button:'#send-pitch-gain-button',
+      roll_send_button:'#send-roll-gain-button',
+      heading_send_button:'#send-heading-gain-button',
+      altitude_send_button:'#send-altitude-gain-button',
+      throttle_send_button:'#send-throttle-gain-button',
+      flap_send_button:'#send-flap-gain-button',
+      path_send_button:'#send-path-gain-button',
+      orbit_send_button:'#send-path-gain-button'
+    },
+
+    events:{
+      'click #send-yaw-gain-button':'sendYawGains',
+      'click #send-pitch-gain-button':'sendPitchGains',
+      'click #send-roll-gain-button':'sendRollGains',
+      'click #send-heading-gain-button':'sendHeadingGains',
+      'click #send-altitude-gain-button':'sendAltitudeGains',
+      'click #send-throttle-gain-button':'sendThrottleGains',
+      'click #send-flap-gain-button':'sendFlapGains',
+      'click #send-orbit-gain-button':'sendOrbitGains',
+      'click #send-path-gain-button':'sendPathGains'
     },
 
     initialize: function(){
-      
+      this.verification_quoue=[];//verifies that the gain value sent is the one thats being used
     },
     onRender:function(){
-      TelemetryData.addListener('data_received'. function(){
-        console.log('data_received');
+      TelemetryData.addListener('data_received',function(data){
+        if(this.verification_quoue.length>0 && data.editing_gain===this.verification_quoue[0].type && data.kd_gain===this.verification_quoue[0].kd
+            && data.kp_gain===this.verification_quoue[0].kp && data.ki_gain===this.verification_quoue[0].ki){
+          this.verification_quoue[0].button.text('Send');
+          this.verification_quoue.shift();
+          Commands.showGain(this.verification_quoue[0].type);
+        }
       });
     },
     onBeforeDestroy:function(){
       
     },
-    onDestroy:function(){
-     
+
+    addToVerificationQuoue: function(object){
+      //get rid of any verification requests of the same type
+      for(var i=0;i<this.verification_quoue.length;i++){
+        if(this.verification_quoue[i].type===object.type){
+          this.verification_quoue.splice(i,1);
+          i--;
+        }
+      }
+      this.verification_quoue.push(object);
+      object.button.text('Verifiying..');
+      Commands.showGain(this.verification_quoue[0].type);
     },
 
-    clickCallback:function(event){ 
-
+    sendYawGains: function(){
+      var ki=this.ui.yaw_ki.val();
+      var kd=this.ui.yaw_kd.val();
+      var kp=this.ui.yaw_kp.val();
+      Commands.sendKPGain('yaw',kp);
+      Commands.sendKIGain('yaw',ki);
+      Commands.sendKDGain('yaw',kd);
+      this.addToVerificationQuoue({
+        type: GAINS.YAW,
+        ki: ki,
+        kp: kp,
+        kd: kd,
+        button: this.ui.yaw_send_button
+      });
+    },
+    sendPitchGains: function(){
+      var ki=this.ui.pitch_ki.val();
+      var kd=this.ui.pitch_kd.val();
+      var kp=this.ui.pitch_kp.val();
+      Commands.sendKPGain('pitch',kp);
+      Commands.sendKIGain('pitch',ki);
+      Commands.sendKDGain('pitch',kd);
+      this.addToVerificationQuoue({
+        type: GAINS.PITCH,
+        ki: ki,
+        kp: kp,
+        kd: kd,
+        button: this.ui.pitch_send_button
+      });
+    },
+    sendRollGains: function(){
+      var ki=this.ui.roll_ki.val();
+      var kd=this.ui.roll_kd.val();
+      var kp=this.ui.roll_kp.val();
+      Commands.sendKPGain('roll',kp);
+      Commands.sendKIGain('roll',ki);
+      Commands.sendKDGain('roll',kd);
+      this.addToVerificationQuoue({
+        type: GAINS.ROLL,
+        ki: ki,
+        kp: kp,
+        kd: kd,
+        button: this.ui.roll_send_button
+      });
+    },
+    sendHeadingGains: function(){
+      var ki=this.ui.heading_ki.val();
+      var kd=this.ui.heading_kd.val();
+      var kp=this.ui.heading_kp.val();
+      Commands.sendKPGain('heading',kp);
+      Commands.sendKIGain('heading',ki);
+      Commands.sendKDGain('heading',kd);
+      this.addToVerificationQuoue({
+        type: GAINS.HEADING,
+        ki: ki,
+        kp: kp,
+        kd: kd,
+        button: this.ui.heading_send_button
+      });
+    },
+    sendAltitudeGains: function(){
+      var ki=this.ui.altitude_ki.val();
+      var kd=this.ui.altitude_kd.val();
+      var kp=this.ui.altitude_kp.val();
+      Commands.sendKPGain('altitude',kp);
+      Commands.sendKIGain('altitude',ki);
+      Commands.sendKDGain('altitude',kd);
+      this.addToVerificationQuoue({
+        type: GAINS.ALTITUDE,
+        ki: ki,
+        kp: kp,
+        kd: kd,
+        button: this.ui.altitude_send_button
+      });
+    },
+    sendThrottleGains: function(){
+      var ki=this.ui.throttle_ki.val();
+      var kd=this.ui.throttle_kd.val();
+      var kp=this.ui.throttle_kp.val();
+      Commands.sendKPGain('throttle',kp);
+      Commands.sendKIGain('throttle',ki);
+      Commands.sendKDGain('throttle',kd);
+      this.addToVerificationQuoue({
+        type: GAINS.THROTTLE,
+        ki: ki,
+        kp: kp,
+        kd: kd,
+        button: this.ui.throttle_send_button
+      });
+    },
+    sendFlapGains: function(){
+      var ki=this.ui.flap_ki.val();
+      var kd=this.ui.flap_kd.val();
+      var kp=this.ui.flap_kp.val();
+      Commands.sendKPGain('flap',kp);
+      Commands.sendKIGain('flap',ki);
+      Commands.sendKDGain('flap',kd);
+      //support for flap gain verification is not implemented in the picpilot yet
+      // this.addToVerificationQuoue({
+      //   type: GAINS.FLAP,
+      //   ki: ki,
+      //   kp: kp,
+      //   kd: kd,
+      //   button: this.ui.flap_send_button
+      // });
+    },
+    sendOrbitalGains: function(){
+      var kp=this.ui.orbit_kp.val();
+      Commands.sendOrbitGain(kp);
+      //support for path and orbit gains verification is not implemented via the picpilot yet
+    },
+    sendPathGains: function(){
+      var kp=this.ui.path_kp.val();
+      Commands.sendPathGain(kp);
+      //support for path and orbit gains verification is not implemented via the picpilot yet
+    },
+    sendAllGains: function(){
+      this.sendYawGains();
+      this.sendPitchGains();
+      this.sendROllGains();
+      this.sendHeadinGains();
+      this.sendAltitudeGains();
+      this.sendThrottleGains();
+      this.sendFlapGains();
+      this.sendOrbitalGains();
+      this.sendPathGains();
     }
   });
 };

--- a/app/views/GainsAdjustView.js
+++ b/app/views/GainsAdjustView.js
@@ -57,6 +57,7 @@ module.exports=function(Marionette){
     },
 
     events:{
+      'click #send-all-gains-button':'sendAllGains',
       'click #send-yaw-gain-button':'sendYawGains',
       'click #send-pitch-gain-button':'sendPitchGains',
       'click #send-roll-gain-button':'sendRollGains',
@@ -64,25 +65,34 @@ module.exports=function(Marionette){
       'click #send-altitude-gain-button':'sendAltitudeGains',
       'click #send-throttle-gain-button':'sendThrottleGains',
       'click #send-flap-gain-button':'sendFlapGains',
-      'click #send-orbit-gain-button':'sendOrbitGains',
+      'click #send-orbit-gain-button':'sendOrbitalGains',
       'click #send-path-gain-button':'sendPathGains'
     },
 
     initialize: function(){
       this.verification_quoue=[];//verifies that the gain value sent is the one thats being used
+      this.data_callback=null;
     },
+    
     onRender:function(){
-      TelemetryData.addListener('data_received',function(data){
-        if(this.verification_quoue.length>0 && data.editing_gain===this.verification_quoue[0].type && data.kd_gain===this.verification_quoue[0].kd
-            && data.kp_gain===this.verification_quoue[0].kp && data.ki_gain===this.verification_quoue[0].ki){
-          this.verification_quoue[0].button.text('Send');
-          this.verification_quoue.shift();
-          Commands.showGain(this.verification_quoue[0].type);
-        }
-      });
+      this.data_callback=this.dataCallback.bind(this);
+      TelemetryData.addListener('data_received',this.data_callback);
     },
+
     onBeforeDestroy:function(){
-      
+      TelemetryData.removeListener('data_received',this.data_callback);
+    },
+
+    dataCallback: function(data){
+      console.log('Receiviung dataa!!');
+      console.log(this.verification_quoue);
+
+      if(this.verification_quoue.length>0 && data.editing_gain===this.verification_quoue[0].type && data.kd_gain===this.verification_quoue[0].kd
+          && data.kp_gain===this.verification_quoue[0].kp && data.ki_gain===this.verification_quoue[0].ki){
+        this.verification_quoue[0].button.text('Send');
+        this.verification_quoue.shift();
+        Commands.showGain(this.verification_quoue[0].type);
+      }
     },
 
     addToVerificationQuoue: function(object){
@@ -217,8 +227,8 @@ module.exports=function(Marionette){
     sendAllGains: function(){
       this.sendYawGains();
       this.sendPitchGains();
-      this.sendROllGains();
-      this.sendHeadinGains();
+      this.sendRollGains();
+      this.sendHeadingGains();
       this.sendAltitudeGains();
       this.sendThrottleGains();
       this.sendFlapGains();

--- a/app/views/GainsAdjustView.js
+++ b/app/views/GainsAdjustView.js
@@ -1,6 +1,9 @@
 var Template=require('../util/Template');
 var TelemetryData=require('../models/TelemetryData');
 var Commands=require('../models/Commands');
+var Validator=require('../util/Validator');
+
+var gains_config=require('../../config/gains-config');
 
 var GAINS={
   YAW: 0x00,
@@ -58,6 +61,9 @@ module.exports=function(Marionette){
 
     events:{
       'click #send-all-gains-button':'sendAllGains',
+      'click #save-all-gains-button':'saveChanges',
+      'click #discard-all-gains-button':'discardChanges',
+      'click #reset-default-gains-button':'resetToDefault',
       'click #send-yaw-gain-button':'sendYawGains',
       'click #send-pitch-gain-button':'sendPitchGains',
       'click #send-roll-gain-button':'sendRollGains',
@@ -77,6 +83,7 @@ module.exports=function(Marionette){
     onRender:function(){
       this.data_callback=this.dataCallback.bind(this);
       TelemetryData.addListener('data_received',this.data_callback);
+      this.discardChanges(); //fills in the values from the settings
     },
 
     onBeforeDestroy:function(){
@@ -231,6 +238,93 @@ module.exports=function(Marionette){
       this.sendFlapGains();
       this.sendOrbitalGains();
       this.sendPathGains();
+    },
+    //saves the gain if its a valid number
+    checkAndSaveGain: function(id,value){
+      if(Validator.isValidNumber(value)){
+        gains_config.set(id,Number(value));
+      } 
+      else{ 
+        Logger.error('Did not save '+id+' gain as its not a valid number');
+      }
+    },
+
+    saveChanges: function(){
+      this.checkAndSaveGain('yaw_kd',this.ui.yaw_kd.val());
+      this.checkAndSaveGain('yaw_ki',this.ui.yaw_ki.val());
+      this.checkAndSaveGain('yaw_kp',this.ui.yaw_kp.val());
+      this.checkAndSaveGain('pitch_kd',this.ui.pitch_kd.val());
+      this.checkAndSaveGain('pitch_ki',this.ui.pitch_ki.val());
+      this.checkAndSaveGain('pitch_kp',this.ui.pitch_kp.val());
+      this.checkAndSaveGain('roll_kd',this.ui.roll_kd.val());
+      this.checkAndSaveGain('roll_ki',this.ui.roll_ki.val());
+      this.checkAndSaveGain('roll_kp',this.ui.roll_kp.val());
+      this.checkAndSaveGain('heading_kd',this.ui.heading_kd.val());
+      this.checkAndSaveGain('heading_ki',this.ui.heading_ki.val());
+      this.checkAndSaveGain('heading_kp',this.ui.heading_kp.val());
+      this.checkAndSaveGain('altitude_kd',this.ui.altitude_kd.val());
+      this.checkAndSaveGain('altitude_ki',this.ui.altitude_ki.val());
+      this.checkAndSaveGain('altitude_kp',this.ui.altitude_kp.val());
+      this.checkAndSaveGain('throttle_kd',this.ui.throttle_kd.val());
+      this.checkAndSaveGain('throttle_ki',this.ui.throttle_ki.val());
+      this.checkAndSaveGain('throttle_kp',this.ui.throttle_kp.val());
+      this.checkAndSaveGain('flap_kd',this.ui.flap_kd.val());
+      this.checkAndSaveGain('flap_ki',this.ui.flap_ki.val());
+      this.checkAndSaveGain('flap_kp',this.ui.flap_kp.val());
+      this.checkAndSaveGain('orbit_kp',this.ui.orbit_kp.val());
+      this.checkAndSaveGain('path_kp',this.ui.path_kp.val());
+    },
+    discardChanges: function(){
+      this.ui.yaw_kd.val(gains_config.get('yaw_kd'));
+      this.ui.yaw_ki.val(gains_config.get('yaw_ki'));
+      this.ui.yaw_kp.val(gains_config.get('yaw_kp'));
+      this.ui.pitch_kd.val(gains_config.get('pitch_kd'));
+      this.ui.pitch_ki.val(gains_config.get('pitch_ki'));
+      this.ui.pitch_kp.val(gains_config.get('pitch_kp'));
+      this.ui.roll_kd.val(gains_config.get('roll_kd'));
+      this.ui.roll_ki.val(gains_config.get('roll_ki'));
+      this.ui.roll_kp.val(gains_config.get('roll_kp'));
+      this.ui.heading_kd.val(gains_config.get('heading_kd'));
+      this.ui.heading_ki.val(gains_config.get('heading_ki'));
+      this.ui.heading_kp.val(gains_config.get('heading_kp'));
+      this.ui.altitude_kd.val(gains_config.get('altitude_kd'));
+      this.ui.altitude_ki.val(gains_config.get('altitude_ki'));
+      this.ui.altitude_kp.val(gains_config.get('altitude_kp'));
+      this.ui.throttle_kd.val(gains_config.get('throttle_kd'));
+      this.ui.throttle_ki.val(gains_config.get('throttle_ki'));
+      this.ui.throttle_kp.val(gains_config.get('throttle_kp'));
+      this.ui.flap_kd.val(gains_config.get('flap_kd'));
+      this.ui.flap_ki.val(gains_config.get('flap_ki'));
+      this.ui.flap_kp.val(gains_config.get('flap_kp'));
+      this.ui.orbit_kp.val(gains_config.get('orbit_kp'));
+      this.ui.path_kp.val(gains_config.get('path_kp'));
+    },
+    resetToDefault:function(){
+      this.ui.yaw_kd.val(gains_config.default_settings['yaw_kd']);
+      this.ui.yaw_ki.val(gains_config.default_settings['yaw_ki']);
+      this.ui.yaw_kp.val(gains_config.default_settings['yaw_kp']);
+      this.ui.pitch_kd.val(gains_config.default_settings['pitch_kd']);
+      this.ui.pitch_ki.val(gains_config.default_settings['pitch_ki']);
+      this.ui.pitch_kp.val(gains_config.default_settings['pitch_kp']);
+      this.ui.roll_kd.val(gains_config.default_settings['roll_kd']);
+      this.ui.roll_ki.val(gains_config.default_settings['roll_ki']);
+      this.ui.roll_kp.val(gains_config.default_settings['roll_kp']);
+      this.ui.heading_kd.val(gains_config.default_settings['heading_kd']);
+      this.ui.heading_ki.val(gains_config.default_settings['heading_ki']);
+      this.ui.heading_kp.val(gains_config.default_settings['heading_kp']);
+      this.ui.altitude_kd.val(gains_config.default_settings['altitude_kd']);
+      this.ui.altitude_ki.val(gains_config.default_settings['altitude_ki']);
+      this.ui.altitude_kp.val(gains_config.default_settings['altitude_kp']);
+      this.ui.throttle_kd.val(gains_config.default_settings['throttle_kd']);
+      this.ui.throttle_ki.val(gains_config.default_settings['throttle_ki']);
+      this.ui.throttle_kp.val(gains_config.default_settings['throttle_kp']);
+      this.ui.flap_kd.val(gains_config.default_settings['flap_kd']);
+      this.ui.flap_ki.val(gains_config.default_settings['flap_ki']);
+      this.ui.flap_kp.val(gains_config.default_settings['flap_kp']);
+      this.ui.orbit_kp.val(gains_config.default_settings['orbit_kp']);
+      this.ui.path_kp.val(gains_config.default_settings['path_kp']);
+
+      this.saveChanges();
     }
   });
 };

--- a/config/gains-config.js
+++ b/config/gains-config.js
@@ -1,0 +1,27 @@
+var SettingsLoader=require('../app/util/SettingsLoader');
+
+var gains_config={
+  yaw_kp: 32,
+  yaw_kd: 34,
+  yaw_ki: 34,
+  pitch_kp: 32,
+  pitch_kd: 34,
+  pitch_ki: 34,
+  roll_kp: 32,
+  roll_kd: 34,
+  roll_ki: 34,
+  heading_kp: 32,
+  heading_kd: 34,
+  heading_ki: 34,
+  altitude_kp: 32,
+  altitude_kd: 34,
+  altitude_ki: 34,
+  throttle_kp: 32,
+  throttle_kd: 34,
+  throttle_ki: 34,
+  flap_kp: 32,
+  flap_kd: 34,
+  flap_ki: 34
+};
+
+module.exports=new SettingsLoader('gains_config',gains_config);

--- a/config/gains-config.js
+++ b/config/gains-config.js
@@ -1,27 +1,30 @@
 var SettingsLoader=require('../app/util/SettingsLoader');
 
+//NOTE: all of these MUST be numbers
 var gains_config={
-  yaw_kp: 32,
-  yaw_kd: 34,
-  yaw_ki: 34,
-  pitch_kp: 32,
-  pitch_kd: 34,
-  pitch_ki: 34,
-  roll_kp: 32,
-  roll_kd: 34,
-  roll_ki: 34,
-  heading_kp: 32,
-  heading_kd: 34,
-  heading_ki: 34,
-  altitude_kp: 32,
-  altitude_kd: 34,
-  altitude_ki: 34,
-  throttle_kp: 32,
-  throttle_kd: 34,
-  throttle_ki: 34,
-  flap_kp: 32,
-  flap_kd: 34,
-  flap_ki: 34
+  yaw_kp: 1,
+  yaw_kd: 2,
+  yaw_ki: 3,
+  pitch_kp: 4,
+  pitch_kd: 5,
+  pitch_ki: 6,
+  roll_kp: 7,
+  roll_kd: 8,
+  roll_ki: 9,
+  heading_kp: 10,
+  heading_kd: 11,
+  heading_ki: 12,
+  altitude_kp: 13,
+  altitude_kd: 14,
+  altitude_ki: 15,
+  throttle_kp: 16,
+  throttle_kd: 17,
+  throttle_ki: 18,
+  flap_kp: 19,
+  flap_kd: 20,
+  flap_ki: 21,
+  orbit_kp: 22,
+  path_kp: 23
 };
 
 module.exports=new SettingsLoader('gains_config',gains_config);

--- a/styles/views/gains-adjust-view.css
+++ b/styles/views/gains-adjust-view.css
@@ -4,7 +4,6 @@
   text-align: center;
   padding: 12px;
   box-sizing: border-box;
-  background-color: rgba(0,0,0,0.8);
 }
 .gainsAdjustView h1{
   margin-top: 4px;

--- a/views/GainsAdjustView.html
+++ b/views/GainsAdjustView.html
@@ -85,5 +85,7 @@
 
 <div class="pure-form" style="margin-top: 12px">
     <button id="send-all-gains-button" class="pure-button button-secondary">Send All</button>
+    <button id="save-all-gains-button" class="pure-button button-success">Save All</button>
+    <button id="discard-all-gains-button" class="pure-button button-warning">Discard Changes</button>
     <button id="reset-default-gains-button" class="pure-button button-error">Reset to Default</button>
 </div>

--- a/views/GainsAdjustView.html
+++ b/views/GainsAdjustView.html
@@ -83,7 +83,7 @@
     </tbody>
 </table>
 
-<form class="pure-form" style="margin-top: 12px">
+<div class="pure-form" style="margin-top: 12px">
     <button id="send-all-gains-button" class="pure-button button-secondary">Send All</button>
     <button id="reset-default-gains-button" class="pure-button button-error">Reset to Default</button>
-</form>
+</div>

--- a/views/GainsAdjustView.html
+++ b/views/GainsAdjustView.html
@@ -60,6 +60,29 @@
     </tbody>
 </table>
 
+<table class="pure-table" style="margin-top: 12px;">
+    <thead>
+        <tr>
+            <th>Type</th>
+            <th>Orbit</th>
+            <th>Path</th>
+        </tr>
+    </thead>
+
+    <tbody>
+        <tr>
+            <td>KP</td>
+            <td><form class="pure-form"><input id="orbit-kp" type="text"></form></td>
+            <td><form class="pure-form"><input id="path-kp" type="text"></form></td>
+        </tr>
+        <tr>
+          <td></td>
+          <td><button id="send-orbit-gain-button" class="pure-button button-success">Send</button></td>
+          <td><button id="send-path-gain-button" class="pure-button button-success">Send</button></td>
+        </tr>
+    </tbody>
+</table>
+
 <form class="pure-form" style="margin-top: 12px">
     <button id="send-all-gains-button" class="pure-button button-secondary">Send All</button>
     <button id="reset-default-gains-button" class="pure-button button-error">Reset to Default</button>


### PR DESCRIPTION
Here are the steps the user would take to send a certain gain to the plane:

- Window opens up with initial gain values from the application settings
- User sends the gain value (eg. yaw)
- The ground station sends three commands, one for each of the ki,kp, and kd gains
- The ground station adds the command to the verification queue, which will send set_editingGain= whatever the yaw is to the picpilot when the command is the first in the quoue
- After data is received from the plane, and it is found the the picpilot is using the gain settings for the yaw that the ground station sent, the command is removed from the verification queue, and the next one if any is verified

The point of the verification quoue is so that we can send yaw, pitch, roll, etc gains all at the same time and verifiy them individually.

![image](https://cloud.githubusercontent.com/assets/4944703/13118139/d74721ec-d570-11e5-838a-b98368a675dc.png)