### PR TITLE
Sending new packet types

### DIFF
--- a/app/connections/DataRelay.js
+++ b/app/connections/DataRelay.js
@@ -2,13 +2,11 @@
  * @author Serge Babayan
  * @module connections/DataRelay
  * @requires config/network-config
- * @requires config/map-config
  * @requires Network
  * @requires util/Logger
  * @requires util/PacketParser
  * @requires StatusManger
  * @requires models/TelemetryData
- * @emits models/TelemetryData~TelemetryData:data_received
  * @emits models/TelemetryData~TelemetryData:aircraft_position
  * @emits models/TelemetryData~TelemetryData:aircraft_orientation
  * @emits models/TelemetryData~TelemetryData:aircraft_gains
@@ -31,31 +29,17 @@ var _ = require('underscore');
 var DataRelay = {};
 
 DataRelay.parseHeaders = function (data) {
-  TelemetryData.headers = data.split(",").map(function (str) {
-    return str.trim();
-  });
-
-  PacketParser.checkForMissingHeaders(data);
+  TelemetryData.setHeadersFromString(data);
+  PacketParser.checkForMissingHeaders(TelemetryData.headers);
 
   Logger.debug('Network data_relay Received headers: ' + data);
-  Logger.data(TelemetryData.headers, 'DATA_RELAY_HEADERS');
+  Logger.data(JSON.stringify(TelemetryData.headers), 'DATA_RELAY_HEADERS');
   StatusManager.addStatus('Received headers from data_relay', 3, 3000);
 };
 
-
 DataRelay.parseData = function (data) {
-  var sorted_data = PacketParser.parseData(data, TelemetryData.headers);
-
-  _.each(sorted_data, function (packet_data, packet_type_name) {
-    TelemetryData.emit(packet_type_name, packet_data);
-  });
-
-  data.split(",").map(function (data_value, index) {
-    TelemetryData.current_state[TelemetryData.headers[index]] = data_value.trim();
-  });
-
-  TelemetryData.state_history.push(TelemetryData.current_state);
-  TelemetryData.emit('data_received', TelemetryData.current_state);
+  TelemetryData.current_state = PacketParser.parseData(data, TelemetryData.headers);
+  TelemetryData.emitPackets(TelemetryData.current_state);
 
   Logger.data(JSON.stringify(TelemetryData.current_state), 'DATA_RELAY_DATA');
   StatusManager.setStatusCode('TIMEOUT_DATA_RELAY', false);
@@ -75,11 +59,11 @@ DataRelay.init = function () {
   data_relay.socket.setTimeout(network_config.get('datarelay_timeout'));
 
   data_relay.on('connect', function () {
+    TelemetryData.headers = [];
     StatusManager.setStatusCode('CONNECTED_DATA_RELAY', true);
   });
 
   data_relay.on('close', function (had_error) {
-    TelemetryData.headers = []; //this is important. So that we can properly parse the headers next time
     StatusManager.setStatusCode('DISCONNECTED_DATA_RELAY', true);
   });
 
@@ -89,10 +73,6 @@ DataRelay.init = function () {
 
   data_relay.on('write', function (data) {
     StatusManager.addStatus('Sent command to data_relay', 3, 2000);
-    TelemetryData.sent.push({
-      time: new Date(),
-      data: data
-    });
   });
 
   data_relay.on('data', function (data) {
@@ -102,11 +82,6 @@ DataRelay.init = function () {
     }
 
     data = data.toString();
-
-    TelemetryData.received.push({
-      time: new Date(),
-      data: data
-    });
 
     // First transmission is header columns
     if (TelemetryData.headers.length === 0) {

--- a/app/connections/DataRelay.js
+++ b/app/connections/DataRelay.js
@@ -5,7 +5,7 @@
  * @requires Network
  * @requires util/Logger
  * @requires util/PacketParser
- * @requires StatusManger
+ * @requires StatusManager
  * @requires models/TelemetryData
  * @emits models/TelemetryData~TelemetryData:aircraft_position
  * @emits models/TelemetryData~TelemetryData:aircraft_orientation
@@ -18,6 +18,7 @@
  * to the TelemetryData module
  * @see http://docs.uwarg.com/picpilot/datalink/
  */
+
 var network_config = require('../../config/network-config');
 var Network = require('../Network');
 var Logger = require('../util/Logger');
@@ -51,12 +52,13 @@ DataRelay.parseData = function (data) {
  */
 DataRelay.init = function () {
   if (Network.connections['data_relay']) { //if a connection has already been established, disconnect it
+    Network.connections['data_relay'].removeAllListeners();
     Network.connections['data_relay'].disconnect();
   }
 
   var data_relay = Network.addConnection('data_relay', network_config.get('datarelay_host'), network_config.get('datarelay_port'));
 
-  data_relay.socket.setTimeout(network_config.get('datarelay_timeout'));
+  data_relay.setTimeout(network_config.get('datarelay_timeout'));
 
   data_relay.on('connect', function () {
     TelemetryData.headers = [];

--- a/app/models/Connection.js
+++ b/app/models/Connection.js
@@ -44,6 +44,12 @@ var Connection = function (options) {
    */
   this.closed = true;
 
+  /**
+   * Timeout for the socket in milliseconds. Defaults to 5 seconds
+   * @type {number}
+   */
+  this.timeout = 5000;
+
   // Initialize necessary properties from `EventEmitter` in this instance
   EventEmitter.call(this);
 
@@ -74,6 +80,15 @@ var Connection = function (options) {
   };
 
   /**
+   * Sets the timeout for the socket connection in milliseconds
+   * @function setTimeout
+   * @param {int} timeout
+   */
+  this.setTimeout = function(timeout){
+    this.socket.setTimeout(timeout);
+  };
+
+  /**
    * Attempts to send data through the socket
    * @param data {Object} The data to send
    * @fires Connection:write
@@ -97,6 +112,7 @@ var Connection = function (options) {
    * @type {net.Socket}
    */
   this.socket = new net.Socket();
+  this.socket.setTimeout(this.timeout);
 
   this.socket.on('connect', function () {
     /**
@@ -129,8 +145,7 @@ var Connection = function (options) {
    */
   this.socket.on('timeout', function () {
     this.emit('timeout');
-    //TODO: Set the timeout programmatically in the log message
-    Logger.error('Timed out for 5s for ' + this.name + ' connection (host: ' + this.host + ',port:' + this.port + ')');
+    Logger.error('Timed out for ' + this.timeout/1000 + 's for ' + this.name + ' connection (host: ' + this.host + ',port:' + this.port + ')');
   }.bind(this));
 
   /**

--- a/app/models/Connection.js
+++ b/app/models/Connection.js
@@ -129,6 +129,7 @@ var Connection = function (options) {
    */
   this.socket.on('timeout', function () {
     this.emit('timeout');
+    //TODO: Set the timeout programmatically in the log message
     Logger.error('Timed out for 5s for ' + this.name + ' connection (host: ' + this.host + ',port:' + this.port + ')');
   }.bind(this));
 

--- a/app/util/PacketParser.js
+++ b/app/util/PacketParser.js
@@ -79,7 +79,9 @@ var PacketParser = {
       return {};
     }
 
-    var data_array = data.split(",");
+    var data_array = data.split(",").map(function(data){
+      return data.trim();
+    });
     var sorted_data = {};
     var current_state = {};
 
@@ -98,7 +100,7 @@ var PacketParser = {
 
       _.each(packet_headers, function (validators, header_name) {
         //if it is null, that means the data relay intentionally didn't send us the data
-        if (current_state[header_name] === null) {
+        if (current_state[header_name] === '') {
           packet_data[header_name] = null;
         }
         //warn the user if we didn't receive a piece of data (happens if we don't receive enough data)

--- a/app/util/PacketParser.js
+++ b/app/util/PacketParser.js
@@ -52,7 +52,7 @@ var PacketParser = {
       }
     });
   },
-
+  
   /**
    * Converts a string of data into a packet type object, to be emitted by the TelemetryData module.
    * Uses the PacketTypes module in order to sort the headers into the appropriate packet types as well
@@ -75,6 +75,10 @@ var PacketParser = {
    * }
    */
   parseData: function (data, headers_array) {
+    if(!data || !headers_array){
+      return {};
+    }
+
     var data_array = data.split(",");
     var sorted_data = {};
     var current_state = {};

--- a/test/app/connections/DataRelayTest.js
+++ b/test/app/connections/DataRelayTest.js
@@ -1,0 +1,189 @@
+var chai = require("chai");
+var sinon = require("sinon");
+var rewire = require("rewire");
+var expect = chai.expect;
+require('../../../tests-config')(chai);
+var EventEmitter = require('events');
+var network_config = require('../../../config/network-config');
+
+describe('DataRelay', function () {
+  var sandbox = sinon.sandbox.create();
+  var DataRelay = rewire('../../../app/connections/DataRelay');
+  var Network = {};
+  var TelemetryData = {
+    headers: []
+  };
+  var Logger = {};
+  var StatusManager = {
+    addStatus: sandbox.spy(),
+    setStatusCode: sandbox.spy()
+  };
+  var PacketParser = {};
+  var connection = new EventEmitter();
+
+  beforeEach(function () {
+    DataRelay.__set__({
+      'Network': Network,
+      'TelemetryData': TelemetryData,
+      'Logger': Logger,
+      'StatusManager': StatusManager,
+      'PacketParser': PacketParser
+    });
+  });
+
+  afterEach(function () {
+    TelemetryData.headers = [];
+    sandbox.restore();
+
+    StatusManager.addStatus.reset();
+    StatusManager.setStatusCode.reset();
+  });
+
+  describe('init', function () {
+    beforeEach(function () {
+      Network.connections = [];
+      Network.addConnection = sandbox.stub();
+      connection.setTimeout = sandbox.spy();
+      connection.disconnect = sandbox.spy();
+      Network.addConnection.returns(connection);
+      Logger.error = sandbox.spy();
+    });
+
+    afterEach(function () {
+      Network.connections = [];
+      connection.removeAllListeners();
+    });
+
+    it('should correctly add a connection with name of data relay', function () {
+      DataRelay.init();
+      expect(Network.addConnection).to.have.been.calledWith('data_relay', network_config.get('datarelay_host'), network_config.get('datarelay_port'));
+    });
+
+    it('should disconnect the data relay connection if it already exists', function () {
+      Network.connections['data_relay'] = connection;
+      DataRelay.init();
+      expect(connection.disconnect).to.have.been.callCount(1);
+    });
+
+    it('should set the correct timeout for the connection', function () {
+      DataRelay.init();
+      expect(connection.setTimeout).to.have.been.calledWith(network_config.get('datarelay_timeout'));
+    });
+
+    it('given data event call parseHeaders if its the first packet of data', function () {
+      var data = '654,654';
+      var data_buffer = new Buffer(data);
+      var parseHeadersSpy = sandbox.stub(DataRelay, 'parseHeaders');
+      TelemetryData.headers = [];
+      DataRelay.init();
+      connection.emit('data', data_buffer);
+      expect(parseHeadersSpy).to.have.been.calledWith(data);
+    });
+
+    it('given data event call parseData if its not the first packet of data', function () {
+      var data = '654,654';
+      var data_buffer = new Buffer(data);
+      TelemetryData.headers = ['header1', 'header2'];
+      var parseDataSpy = sandbox.stub(DataRelay, 'parseData');
+      DataRelay.init();
+      connection.emit('data', data_buffer);
+      expect(parseDataSpy).to.have.been.calledWith(data);
+    });
+
+    it('warn the user if it receives a blank data packet', function () {
+      DataRelay.init();
+      connection.emit('data', null);
+      expect(Logger.error).to.have.been.calledWith('Got a blank packet from the data relay station. Value: null');
+    });
+
+    it('should clear TelemetryData headers on a connect event', function () {
+      TelemetryData.headers = ['header1'];
+      DataRelay.init();
+      connection.emit('connect');
+      expect(TelemetryData.headers).to.eql([]);
+    });
+
+    it('should set a status code on a disconnect', function () {
+      DataRelay.init();
+      connection.emit('close');
+      expect(StatusManager.setStatusCode).to.have.been.calledWith('DISCONNECTED_DATA_RELAY', true);
+    });
+
+    it('should set a status code on a timeout', function () {
+      DataRelay.init();
+      connection.emit('timeout');
+      expect(StatusManager.setStatusCode).to.have.been.calledWith('TIMEOUT_DATA_RELAY', true);
+    });
+
+    it('should set a status code on a write', function () {
+      DataRelay.init();
+      connection.emit('write');
+      expect(StatusManager.addStatus).to.have.been.calledWith('Sent command to data_relay');
+    });
+  });
+
+  describe('parseData', function () {
+    beforeEach(function () {
+      TelemetryData.setHeadersFromString = sandbox.spy();
+      PacketParser.checkForMissingHeaders = sandbox.spy();
+      Logger.debug = sandbox.spy();
+      Logger.data = sandbox.spy();
+    });
+    it('should set telemetry data headers', function () {
+      var data = 'header1,header2';
+      DataRelay.parseHeaders(data);
+      expect(TelemetryData.setHeadersFromString).to.have.been.calledWith(data);
+    });
+
+    it('should check for any missing headers', function () {
+      var data = 'header1,header2';
+      TelemetryData.headers = ['header1'];
+      DataRelay.parseHeaders(data);
+      expect(PacketParser.checkForMissingHeaders).to.have.been.calledWith(TelemetryData.headers);
+    });
+
+    it('should log headers', function () {
+      var data = 'header1,header2';
+      DataRelay.parseHeaders(data);
+      expect(Logger.debug).to.have.callCount(1);
+      expect(Logger.data).to.have.callCount(1);
+    });
+
+    it('should add received headers status code', function () {
+      var data = 'header1,header2';
+      DataRelay.parseHeaders(data);
+      expect(StatusManager.addStatus).to.have.callCount(1);
+    });
+  });
+  describe('parseData', function () {
+    beforeEach(function () {
+      TelemetryData.emitPackets = sandbox.spy();
+      PacketParser.parseData = sandbox.stub();
+      Logger.data = sandbox.spy();
+    });
+    it('should set TelemetryData current state', function () {
+      var data = '324,234';
+      PacketParser.parseData.returns(data);
+      DataRelay.parseData(data);
+      expect(PacketParser.parseData).to.have.been.calledWith(data, TelemetryData.headers);
+      expect(TelemetryData.current_state).to.be.eql(data);
+    });
+
+    it('emit data packets', function () {
+      var data = '324,234';
+      PacketParser.parseData.returns(data);
+      DataRelay.parseData(data);
+      expect(TelemetryData.emitPackets).to.have.been.calledWith(TelemetryData.current_state);
+    });
+
+    it('log data packet contents', function () {
+      DataRelay.parseData('something');
+      expect(Logger.data).to.have.callCount(1);
+    });
+
+    it('set timeout status code to false', function () {
+      DataRelay.parseData('something');
+      expect( StatusManager.setStatusCode).to.have.callCount(1);
+    });
+  });
+});

--- a/test/app/connections/DataRelayTest.js
+++ b/test/app/connections/DataRelayTest.js
@@ -41,7 +41,7 @@ describe('DataRelay', function () {
 
   describe('init', function () {
     beforeEach(function () {
-      Network.connections = [];
+      Network.connections = {};
       Network.addConnection = sandbox.stub();
       connection.setTimeout = sandbox.spy();
       connection.disconnect = sandbox.spy();
@@ -63,6 +63,30 @@ describe('DataRelay', function () {
       Network.connections['data_relay'] = connection;
       DataRelay.init();
       expect(connection.disconnect).to.have.been.callCount(1);
+    });
+
+    it('should successfully listen to appripriate events on the connection', function () {
+      DataRelay.init();
+      expect(connection.listenerCount('connect')).to.equal(1);
+      expect(connection.listenerCount('close')).to.equal(1);
+      expect(connection.listenerCount('timeout')).to.equal(1);
+      expect(connection.listenerCount('write')).to.equal(1);
+      expect(connection.listenerCount('data')).to.equal(1);
+    });
+
+    it('should successfully clear event listeners on multiple disconnects', function () {
+      Network.addConnection = function(){
+        Network.connections['data_relay'] = connection;
+        return connection;
+      };
+      DataRelay.init();
+      DataRelay.init();
+      DataRelay.init();
+      expect(connection.listenerCount('connect')).to.equal(1);
+      expect(connection.listenerCount('close')).to.equal(1);
+      expect(connection.listenerCount('timeout')).to.equal(1);
+      expect(connection.listenerCount('write')).to.equal(1);
+      expect(connection.listenerCount('data')).to.equal(1);
     });
 
     it('should set the correct timeout for the connection', function () {

--- a/test/app/util/PacketParserTest.js
+++ b/test/app/util/PacketParserTest.js
@@ -59,6 +59,14 @@ describe('PacketParser', function () {
       PacketParser.checkForMissingHeaders(['header1', 'header2', 'header3', 'header4', 'unexpected_header']);
       expect(Logger.warn).to.have.been.calledWith('An unexpected header was received from the data relay. Header: unexpected_header');
     });
+
+    it('given an empty array should warn user correctly', function(){
+      PacketParser.checkForMissingHeaders([]);
+      expect(Logger.warn).to.have.been.calledWith('Did not receive an expected header! Header: header4');
+      expect(Logger.warn).to.have.been.calledWith('Did not receive an expected header! Header: header3');
+      expect(Logger.warn).to.have.been.calledWith('Did not receive an expected header! Header: header2');
+      expect(Logger.warn).to.have.been.calledWith('Did not receive an expected header! Header: header1');
+    });
   });
 
   describe('parseData', function () {
@@ -233,6 +241,21 @@ describe('PacketParser', function () {
       var result = PacketParser.parseData('99,35,36,85', ['header1', 'header2', 'header3', 'header4']);
       expect(Logger.warn, 'Logger.warn').to.have.been.calledWith('Validation failed for header1. Value: 99');
       expect(result['packetType1']['header1']).to.equal(null);
+    });
+
+    it('given null data should return an empty object', function () {
+      var result = PacketParser.parseData(null, ['header1', 'header2', 'header3', 'header4']);
+      expect(result).to.eql({});
+    });
+
+    it('given null headers should return an empty object', function () {
+      var result = PacketParser.parseData('wef,wef,wef', null);
+      expect(result).to.eql({});
+    });
+
+    it('given an empty array for headers should return null for expected headers', function () {
+      var result = PacketParser.parseData('wef,wef,wef', []);
+      expect(result).to.eql(getExpectedResult(null,null,null,null));
     });
   });
 });

--- a/test/app/util/PacketParserTest.js
+++ b/test/app/util/PacketParserTest.js
@@ -172,6 +172,11 @@ describe('PacketParser', function () {
       expect(result).to.deep.equal(getExpectedResult(34, 35, 36, 37));
     });
 
+    it('given a data value that is an empty string should return null in the expected header', function () {
+      var result = PacketParser.parseData(' , 35, 36, 37', ['header1', 'header2', 'header3', 'header4']);
+      expect(result).to.deep.equal(getExpectedResult(null, 35, 36, 37));
+    });
+
     it('given a header that is not received should warn user and return null for the header value', function () {
       var result = PacketParser.parseData('34, 35, 36', ['header1', 'header2', 'header3']);
       expect(Logger.error).to.have.calledWith('Parsing Error. Value for header header4 not received');


### PR DESCRIPTION
The data relay module will no longer be sending plain 'data_received' events, and will instead send events corresponding to the PacketTypes module. In addition unit tests have been added to the Data Relay module, as well as fixed a potential error for the DataRelay connection not cleaning up its listeners after a forced disconnect.

Also added edge case support for the PacketParser module