### PR TITLE
fix-main-window-closing

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,9 +37,8 @@ app.on('ready', function() {
   // and load the mainWindow.html of the app.
   mainWindow.loadURL('file://' + __dirname + '/templates/windows/mainWindow.html');
 
-  // Emitted when the window is closed.
-  mainWindow.on('closed', function () {
-    app.quit();
-    mainWindow = null;
+  // Emitted when the window is closing.
+  mainWindow.on('close', function () {
+    app.exit(0);     
   });
 });


### PR DESCRIPTION
On win OS the main window doesn't close. Using app.exit to close the
app, which does throw an error code to the terminal but it works.